### PR TITLE
monitoring: replace kube-prometheus-stack with VictoriaMetrics + stan…

### DIFF
--- a/clusters/staging/monitoring.yaml
+++ b/clusters/staging/monitoring.yaml
@@ -10,7 +10,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  path: ./monitoring/staging/kube-prometheus-stack
+  path: ./monitoring/staging/victoria-metrics
   prune: true
   decryption:
     provider: sops

--- a/monitoring/base/victoria-metrics/grafana-storage.yaml
+++ b/monitoring/base/victoria-metrics/grafana-storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data
+  namespace: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/monitoring/base/victoria-metrics/helmrelease-grafana.yaml
+++ b/monitoring/base/victoria-metrics/helmrelease-grafana.yaml
@@ -1,0 +1,35 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: grafana
+      version: ">=8.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: monitoring
+      interval: 12h
+  valuesFrom:
+    - kind: Secret
+      name: grafana-secrets
+      valuesKey: adminPassword
+      targetPath: adminPassword
+  values:
+    persistence:
+      enabled: true
+      existingClaim: grafana-data
+    datasources:
+      datasources.yaml:
+        apiVersion: 1
+        datasources:
+          - name: VictoriaMetrics
+            type: prometheus
+            uid: victoriametrics
+            url: http://victoria-metrics-victoria-metrics-single-server.monitoring.svc:8428
+            access: proxy
+            isDefault: true

--- a/monitoring/base/victoria-metrics/helmrelease-kube-state-metrics.yaml
+++ b/monitoring/base/victoria-metrics/helmrelease-kube-state-metrics.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kube-state-metrics
+      version: ">=5.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: monitoring
+      interval: 12h
+  values:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "8080"

--- a/monitoring/base/victoria-metrics/helmrelease-node-exporter.yaml
+++ b/monitoring/base/victoria-metrics/helmrelease-node-exporter.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: node-exporter
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: prometheus-node-exporter
+      version: ">=4.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: monitoring
+      interval: 12h
+  values:
+    podAnnotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9100"

--- a/monitoring/base/victoria-metrics/helmrelease-victoriametrics.yaml
+++ b/monitoring/base/victoria-metrics/helmrelease-victoriametrics.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-metrics
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: victoria-metrics-single
+      version: ">=0.9.0"
+      sourceRef:
+        kind: HelmRepository
+        name: victoria-metrics
+        namespace: monitoring
+      interval: 12h
+  values:
+    server:
+      persistentVolume:
+        enabled: true
+        size: 2Gi
+      scrape:
+        enabled: true
+        config:
+          global:
+            scrape_interval: 30s
+          scrape_configs:
+            - job_name: kubernetes-pods
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: "true"
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  target_label: __metrics_path__
+                  regex: (.+)
+                - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+                - source_labels: [__meta_kubernetes_namespace]
+                  target_label: namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  target_label: pod

--- a/monitoring/base/victoria-metrics/helmrepository-grafana.yaml
+++ b/monitoring/base/victoria-metrics/helmrepository-grafana.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://grafana.github.io/helm-charts

--- a/monitoring/base/victoria-metrics/helmrepository-prometheus-community.yaml
+++ b/monitoring/base/victoria-metrics/helmrepository-prometheus-community.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts

--- a/monitoring/base/victoria-metrics/helmrepository-victoriametrics.yaml
+++ b/monitoring/base/victoria-metrics/helmrepository-victoriametrics.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: victoria-metrics
+  namespace: monitoring
+spec:
+  interval: 24h
+  url: https://victoriametrics.github.io/helm-charts

--- a/monitoring/base/victoria-metrics/kustomization.yaml
+++ b/monitoring/base/victoria-metrics/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - namespace.yaml
+  - helmrepository-prometheus-community.yaml
+  - helmrepository-grafana.yaml
+  - helmrepository-victoriametrics.yaml
+  - helmrelease-victoriametrics.yaml
+  - helmrelease-grafana.yaml
+  - helmrelease-node-exporter.yaml
+  - helmrelease-kube-state-metrics.yaml
+  - grafana-storage.yaml

--- a/monitoring/base/victoria-metrics/namespace.yaml
+++ b/monitoring/base/victoria-metrics/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/monitoring/staging/victoria-metrics/grafana-secrets.yaml
+++ b/monitoring/staging/victoria-metrics/grafana-secrets.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-secrets
+    namespace: monitoring
+type: Opaque
+stringData:
+    adminPassword: ENC[AES256_GCM,data:Q63x87udyhI=,iv:wqESkpTXpPRtO8mjSJmmKVXd5o2dBgPWdtNW4ta+/fY=,tag:HlxwbbBypSncD22ehoCwug==,type:str]
+sops:
+    age:
+        - recipient: age1nx88s3q0e02zhyycd9q4lwxqts9e6cenrvlxfp7ka2ghaxzwa5hqhex8h6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlQ0VkOVh2cGtTeGloWUNT
+            b0hmQ2t1WjVBWkh4Z0pWNDkvZTdaYW5Ga1FBCkZlMlplR3dpazV0Yk1HekMyam15
+            Z2lwd3lVZzQrUHIyeEQvbkxHWkpYM2cKLS0tIExtbVFENzFmQ0lCNVBYd0RTWFZp
+            dGJoL2YyN3ZrRTBwU0pqUTZ2MDU2UW8KXdoQVwFT/S86ShwihnGuDdkn11/5zbQj
+            hTfRsJJ9I2Oeu2fFkzRueDv33woexR09AQRj8Z9D77fFOrw8vmVQ6A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-12-14T15:03:12Z"
+    mac: ENC[AES256_GCM,data:YurfIaGW4KGolKPlFtgr4zxHxkOSmLg/6kTBPgGcCGvBEXkNPhK8glAI6O4dPdPFJAjxQLIXg1HEQwzUaFQ4aE0+J59SNw/LTyg7aDN6x21WgDfNNgxjJdWNldbEA9MoRye0n8z/kxXN0FxP9rZ+u1H1T9mn/UyU8lnTfz9s6zQ=,iv:lDcXi7sdWz43ZEBM+XlWYZSgU00qMGo0eopsb30uCzc=,tag:CBZSqXGawAXSU+eRxIx+cw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/monitoring/staging/victoria-metrics/kustomization.yaml
+++ b/monitoring/staging/victoria-metrics/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ../../base/victoria-metrics
+  - grafana-secrets.yaml

--- a/skills/review-report/SKILL.md
+++ b/skills/review-report/SKILL.md
@@ -1,0 +1,56 @@
+# Review Report Skill
+
+Use this skill when the user asks for a review report of generated code, or invokes `/review-report`.
+
+## Instructions
+
+Generate a file-by-file code review report. For each file created, modified, or deleted:
+
+1. **Show the file path and status** (created / modified / deleted)
+2. **Show the file's full content** (or just the diff for modified files)
+3. **Add a block below each file** with a short explanation:
+
+```
+> **Pourquoi :** <1-3 lines explaining what this file does and why it's needed. Avoid walls of text. One key insight per file.>
+```
+
+4. **End with a summary section**:
+   - What components are new vs removed vs kept
+   - What happens when deployed (the flow)
+   - What is NOT included and why
+
+## Tone
+
+- Explain the "why", not the "what"
+- 1-3 lines per explanation
+- Use `>` blockquotes for explanations so they visually separate from code
+- Every explanation must answer: "what would break if I deleted this file?"
+
+## Report structure
+
+```
+## N files créés, M modifiés, X supprimés
+
+### 1. `path/to/file.yaml` (créé)
+
+```yaml
+<full content>
+```
+
+> **Pourquoi :** <explanation>
+
+[... repeat for each file ...]
+
+### Résumé
+
+| Composant | Avant | Après |
+|---|---|---|
+...
+```
+
+## Notes
+
+- Always list ALL files, no exceptions
+- Modified files: show just the changed lines with before/after
+- If a file was copied from elsewhere, mention the source
+- Never group explanations across files — one explanation per file


### PR DESCRIPTION
…dalone Grafana

Replace Prometheus (893 MB RAM) with VictoriaMetrics single-node (93 MB RAM). Decompose monolithic HelmRelease into 4 independent components:
  - VictoriaMetrics (scrape + storage, PVC 2Gi)
  - Grafana (reuses existing PVC 5Gi + SOPS secret)
  - node-exporter (host metrics)
  - kube-state-metrics (Kubernetes metrics)

Drop Prometheus Operator and Alertmanager.
Add review-report skill for file-by-file code review format.