### PR TITLE
feat: deploy Glance dashboard with port-forward access

### DIFF
--- a/apps/base/glance/deployment.yaml
+++ b/apps/base/glance/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: glance
+  namespace: apps
+  labels:
+    app: glance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: glance
+  template:
+    metadata:
+      labels:
+        app: glance
+    spec:
+      containers:
+      - name: glance
+        image: glanceapp/glance:v0.8.4
+        ports:
+        - name: web
+          containerPort: 8080
+        volumeMounts:
+        - name: config
+          mountPath: /app/config/glance.yml
+          subPath: glance.yml
+          readOnly: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+      volumes:
+      - name: config
+        configMap:
+          name: glance-config

--- a/apps/base/glance/glance.yml
+++ b/apps/base/glance/glance.yml
@@ -1,0 +1,27 @@
+server:
+  port: 8080
+
+pages:
+  - name: Home
+    columns:
+      - size: full
+        widgets:
+          - type: markets
+            title: Marchés
+            markets:
+              - symbol: BTC-USD
+                name: Bitcoin
+              - symbol: ^MSCI
+                name: MSCI World
+              - symbol: ^GSPC
+                name: S&P 500
+
+      - size: full
+        widgets:
+          - type: monitor
+            title: Mes Services
+            sites:
+              - name: Grafana
+                url: https://grafana.quickyrails.com
+              - name: SaaS Starter
+                url: https://saas-starter.quickyrails.com

--- a/apps/base/glance/kustomization.yaml
+++ b/apps/base/glance/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+configMapGenerator:
+  - name: glance-config
+    files:
+      - glance.yml

--- a/apps/base/glance/service.yaml
+++ b/apps/base/glance/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: glance
+  namespace: apps
+  labels:
+    app: glance
+spec:
+  type: ClusterIP
+  ports:
+  - name: web
+    port: 8080
+    targetPort: web
+    protocol: TCP
+  selector:
+    app: glance

--- a/apps/staging/glance/kustomization.yaml
+++ b/apps/staging/glance/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./saas-starter
-  - ./glance
+  - ../../base/glance


### PR DESCRIPTION
- Add Glance deployment (glanceapp/glance:v0.8.4) in apps namespace
- ConfigMap with glance.yml (BTC, MSCI World, SP500 widgets + Grafana/SaaS links)
- ClusterIP service on port 8080
- Access via kubectl port-forward only