### PR TITLE
feat: add pgadmin deployment

### DIFF
--- a/apps/base/pgadmin/deployment.yaml
+++ b/apps/base/pgadmin/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+  namespace: pgadmin
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: pgadmin
+  template:
+    metadata:
+      labels:
+        app: pgadmin
+    spec:
+      containers:
+        - name: pgadmin
+          image: dpage/pgadmin4:latest
+          ports:
+            - containerPort: 80
+              name: http
+          envFrom:
+            - secretRef:
+                name: pgadmin-env
+          volumeMounts:
+            - name: pgadmin-data
+              mountPath: /var/lib/pgadmin
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: pgadmin-data
+          persistentVolumeClaim:
+            claimName: pgadmin-data

--- a/apps/base/pgadmin/kustomization.yaml
+++ b/apps/base/pgadmin/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./saas-starter
-  - ./pgadmin
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - pvc.yaml

--- a/apps/base/pgadmin/namespace.yaml
+++ b/apps/base/pgadmin/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pgadmin

--- a/apps/base/pgadmin/pvc.yaml
+++ b/apps/base/pgadmin/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pgadmin-data
+  namespace: pgadmin
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/base/pgadmin/service.yaml
+++ b/apps/base/pgadmin/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+  namespace: pgadmin
+spec:
+  selector:
+    app: pgadmin
+  ports:
+    - port: 80
+      targetPort: http

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../base
   - ./saas-starter
+  - ./pgadmin

--- a/apps/staging/pgadmin/app-secrets.yaml
+++ b/apps/staging/pgadmin/app-secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: pgadmin-env
+    namespace: pgadmin
+type: Opaque
+stringData:
+    PGADMIN_DEFAULT_EMAIL: ENC[AES256_GCM,data:g6x3K8Ggbo4W+EgzhH5ziybac0h+UQj3Eg==,iv:JtompUEa2KIaQoaPoX+fQWRfnpWV8cONiLCWTUzVRzY=,tag:6bhd8in8PDJvhustiaTqSQ==,type:str]
+    PGADMIN_DEFAULT_PASSWORD: ENC[AES256_GCM,data:zOlxLjpuGGuln2vmKr453vZoweUD1uC+v5HyBY7KcAc=,iv:GLwGCpPJD0AuDyfQol3PBAMuW+/qUExCT0xyUINfoIo=,tag:JPJyYRQ/HVTqv4TLulo6rw==,type:str]
+sops:
+    age:
+        - recipient: age1nx88s3q0e02zhyycd9q4lwxqts9e6cenrvlxfp7ka2ghaxzwa5hqhex8h6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyK3J3Wi9QODMrV3hMTWlI
+            eUNNSm84U2hnb0FKd3Q3Y21oelNTaWl1cGxNCkppaHNDZ3g3ZGtkcGUvN3RQU2hl
+            U1liTFJoSDkrTS9uN04xSjRzcmhvZGMKLS0tIHBSNjNNZ0NwRUVOSUZiRzJRcmpP
+            MWh3cEZjaSs3emdRSkE2OHNWb0RMdGcKKQ0ooqEgsrO4HebvLaHQ21yfMI0pF+b2
+            mNU66LgF++TsxsjJdqyE1jb4iD+v+NbTmIEIHqCtf/s+jJ8a5fgvDg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-29T19:50:33Z"
+    mac: ENC[AES256_GCM,data:XXi8eup2Xh9adaRYjpTqKvj4T66srTVs8f+XdWy26Bm7DRueJp/emkvMZsa/2I3r/Py92Ub0caLD2gHjCiFxkm8mM8vq60WKJTvvhWqi9zrL78QHqcM64HQEO7qrLGi4gCcUXkQEl5Qiwt8CMPisHb4GcKNyS8bBLFoIt1n50VA=,iv:hFUzKvU0ExDr05fgXNyaiaYrh9zZF83EcMuo+ofRC24=,tag:IoPkyp1WLmQqw3ydIqGEEg==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/apps/staging/pgadmin/kustomization.yaml
+++ b/apps/staging/pgadmin/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./saas-starter
-  - ./pgadmin
+  - app-secrets.yaml


### PR DESCRIPTION
Deploy pgAdmin for internal database management.

- PVC 1Gi local-path for persistent server configs
- Secrets encrypted with SOPS
- Not exposed via Cloudflare (internal access only via kubectl port-forward)