### PR TITLE
fix: move $imagepolicy marker to same line as image tag for FluxCD automation

### DIFF
--- a/apps/base/saas-starter/deployment.yaml
+++ b/apps/base/saas-starter/deployment.yaml
@@ -24,8 +24,7 @@ spec:
         - name: ghcr-registry
       initContainers:
         - name: migrate
-          # {"$imagepolicy": "flux-system:saas-starter"}
-          image: ghcr.io/hermannh34/saas-starter:latest
+          image: ghcr.io/hermannh34/saas-starter:latest # {"$imagepolicy": "flux-system:saas-starter"}
           command: ["npx", "drizzle-kit", "migrate"]
           env:
             - name: POSTGRES_URL
@@ -35,8 +34,7 @@ spec:
                   key: uri
       containers:
         - name: saas-starter
-          # {"$imagepolicy": "flux-system:saas-starter"}
-          image: ghcr.io/hermannh34/saas-starter:latest
+          image: ghcr.io/hermannh34/saas-starter:latest # {"$imagepolicy": "flux-system:saas-starter"}
           ports:
             - containerPort: 3000
               name: http


### PR DESCRIPTION
## Problem

L'ImageUpdateAutomation ne fonctionnait pas car le marqueur `{"": "flux-system:saas-starter"}` était dans un **commentaire sur une ligne séparée** au lieu d'être sur la **même ligne que le tag d'image**.

FluxCD v1beta2 avec `strategy: Setters` nécessite que le marker soit inline :
```yaml
# ❌ Avant (ne fonctionne pas)
# {"$imagepolicy": "flux-system:saas-starter"}
image: ghcr.io/hermannh34/saas-starter:latest

# ✅ Après (fonctionne)
image: ghcr.io/hermannh34/saas-starter:latest # {"$imagepolicy": "flux-system:saas-starter"}
```

## Changes

- `apps/base/saas-starter/deployment.yaml`: déplacé le marker sur la même ligne pour l'initContainer et le container principal