### PR TITLE
fix: correct messageTemplate for saas-starter image update automation

### DIFF
--- a/apps/base/saas-starter/imageupdateautomation.yaml
+++ b/apps/base/saas-starter/imageupdateautomation.yaml
@@ -16,7 +16,7 @@ spec:
       author:
         email: fluxcdbot@users.noreply.github.com
         name: fluxcdbot
-      messageTemplate: "chore(saas-starter): update image to {{range .UpdatedImages}}{{.}}{{end}}"
+      messageTemplate: "chore(saas-starter): bump image tag"
     push:
       branch: main
   update:


### PR DESCRIPTION
## Problem

The `messageTemplate` in `ImageUpdateAutomation` uses invalid Go template syntax:
```
can't evaluate field UpdatedImages in type source.TemplateData
```

## Fix

Changed from:
```yaml
messageTemplate: "chore(saas-starter): update image to {{range .UpdatedImages}}{{.}}{{end}}"
```

To:
```yaml
messageTemplate: "chore(saas-starter): bump image tag"
```

This allows Flux to successfully commit image updates to Git.