### PR TITLE
feat: add Velero backup with Cloudflare R2 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 [![Traefik](https://img.shields.io/badge/Traefik-24A1C1?style=for-the-badge&logo=traefikproxy&logoColor=white)](https://traefik.io/)
 [![GitOps](https://img.shields.io/badge/GitOps-100%25-success?style=for-the-badge)](https://www.gitops.tech/)
 
+[![Velero](https://img.shields.io/badge/Velero-5E81AC?style=for-the-badge&logo=velero&logoColor=white)](https://velero.io/)
+
 ---
 
 **A declarative, semi-production Kubernetes cluster managed entirely through GitOps principles**
@@ -81,6 +83,12 @@ This homelab started with **K3d** for local development, then moved to **VPS ser
 |------------|---------|------|
 | ![Renovate](https://img.shields.io/badge/Renovate-1A1F6C?style=flat-square&logo=renovatebot&logoColor=white) **Renovate** | Dependency | Automated PRs for keeping dependencies update |
 
+### Backup & Recovery
+
+| Technology | Purpose | Why? |
+|------------|---------|------|
+| ![Velero](https://img.shields.io/badge/Velero-5E81AC?style=flat-square&logo=velero&logoColor=white) **Velero** | Backup & Restore | Cluster-wide backup with Cloudflare R2 storage |
+
 
 ---
 
@@ -109,10 +117,12 @@ kubernetes-homelab/
 ├── 🔧 infrastructure/              # Platform services
 │   ├── base/                       # Base manifests
 │   │   ├── cloudflare-tunnel/      # Secure external access
-│   │   └── renovate/               # Automated dependency updates
+│   │   ├── renovate/               # Automated dependency updates
+│   │   └── velero/                 # Cluster backup & recovery
 │   └── staging/                    # Environment secrets & configs
 │       ├── cloudflare-tunnel/
-│       └── renovate/
+│       ├── renovate/
+│       └── velero/
 │
 ├── 📊 monitoring/                  # Observability stack
 │   ├── base/kube-prometheus-stack/ # Prometheus + Grafana
@@ -153,7 +163,7 @@ kubernetes-homelab/
 
 ### 🚀 Short-term Goals 
 - [ ] Implement blue/green deployment
-- [ ] Implement automated Velero Storage and Backup
+- [x] Implement automated Velero Storage and Backup
 - [ ] Infrastructure as Code for the entire setup with Terraform
 
 ### 🏔️ Advanced Goals (6-12 months)

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -50,3 +50,22 @@ spec:
     provider: sops
     secretRef:
       name: sops-age
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: velero
+  namespace: flux-system
+spec:
+  interval: 1m0s
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/staging/velero
+  prune: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/infrastructure/base/velero/helmrelease.yaml
+++ b/infrastructure/base/velero/helmrelease.yaml
@@ -1,0 +1,57 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: velero
+  namespace: velero
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: velero
+      version: ">=8.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: vmware-tanzu
+        namespace: velero
+      interval: 12h
+  values:
+    credentials:
+      useSecret: true
+      secretName: velero-credentials
+      existingSecret: velero-credentials
+    configuration:
+      backupStorageLocation:
+        - name: default
+          provider: aws
+          bucket: ${R2_BUCKET_NAME}
+          config:
+            s3Url: https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com
+            region: auto
+            s3ForcePathStyle: "true"
+      volumeSnapshotLocation:
+        - name: default
+          provider: aws
+          config:
+            region: auto
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.10.0
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - mountPath: /target
+            name: plugins
+    snapshotsEnabled: false
+    deployNodeAgent: true
+    nodeAgent:
+      uploaderType: kopia
+    defaultVolumesToFsUpload: true
+    schedules:
+      daily:
+        disabled: true
+      weekly:
+        schedule: "0 2 * * 0"
+        template:
+          ttl: 720h0m0s
+          includedNamespaces:
+            - "*"
+          storageLocation: default

--- a/infrastructure/base/velero/helmrepository.yaml
+++ b/infrastructure/base/velero/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: vmware-tanzu
+  namespace: velero
+spec:
+  interval: 12h
+  url: https://vmware-tanzu.github.io/helm-charts

--- a/infrastructure/base/velero/kustomization.yaml
+++ b/infrastructure/base/velero/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/infrastructure/base/velero/namespace.yaml
+++ b/infrastructure/base/velero/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero

--- a/infrastructure/staging/velero/kustomization.yaml
+++ b/infrastructure/staging/velero/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: velero
+resources:
+  - ../../base/velero
+  - velero-secrets.yaml

--- a/infrastructure/staging/velero/velero-secrets.yaml
+++ b/infrastructure/staging/velero/velero-secrets.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: velero-credentials
+  namespace: velero
+type: Opaque
+stringData:
+  cloud: |
+    [default]
+    aws_access_key_id=REPLACE_WITH_R2_ACCESS_KEY_ID
+    aws_secret_access_key=REPLACE_WITH_R2_SECRET_ACCESS_KEY


### PR DESCRIPTION
## Velero Backup Implementation

Deploy Velero for cluster-wide backup and recovery with Cloudflare R2 as the storage backend.

### What's included
- **Velero HelmRelease** in dedicated `velero` namespace
- **Weekly backup schedule** (Sunday 2am) with 30-day retention
- **Kopia fs-uploader** for PV backups — no CSI snapshots needed on K3s
- **Cloudflare R2** backend for off-site storage
- **All namespaces** backed up by default

### Files
- `infrastructure/base/velero/` — base manifests (namespace, HelmRepo, HelmRelease)
- `infrastructure/staging/velero/` — staging overlay + credentials secret
- `clusters/staging/infrastructure.yaml` — FluxCD Kustomization for Velero

### Before merging
- [ ] Replace placeholder credentials in `infrastructure/staging/velero/velero-secrets.yaml`
- [ ] Update `R2_ACCOUNT_ID` and `R2_BUCKET_NAME` in `infrastructure/base/velero/helmrelease.yaml`
- [ ] Create the R2 bucket in Cloudflare dashboard

### Checklist
- [x] Follows existing base/staging pattern
- [x] SOPS decryption configured in FluxCD Kustomization
- [x] README updated with Velero badge and docs