### PR TITLE
feat(forgejo): add network policies with default-deny-ingress

### DIFF
--- a/apps/base/forgejo/kustomization.yaml
+++ b/apps/base/forgejo/kustomization.yaml
@@ -4,4 +4,4 @@ resources:
   - namespace.yaml
   - helm-repository.yaml
   - helm-release.yaml
-  #- network-policy.yaml
+  - network-policy.yaml

--- a/apps/base/forgejo/network-policy.yaml
+++ b/apps/base/forgejo/network-policy.yaml
@@ -11,7 +11,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-from-cloudflare-tunnel
+  name: allow-app-ingress
   namespace: forgejo
 spec:
   podSelector: {}
@@ -32,10 +32,12 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-intra-namespace
+  name: allow-db-ingress
   namespace: forgejo
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: forgejo-db
   policyTypes:
     - Ingress
   ingress:
@@ -44,28 +46,5 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: forgejo
       ports:
-        - port: 3000
-          protocol: TCP
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-dns-egress
-  namespace: forgejo
-spec:
-  podSelector: {}
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: kube-dns
-      ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
+        - port: 5432
           protocol: TCP


### PR DESCRIPTION
3 created rules in the forgejo namespace:

- `default-deny-ingress` - blocks all incoming traffic by default
- `allow-app-ingress` - allows Cloudflare Tunnel on port 3000
- `allow-db-ingress` -  allows forgejo to reach its CNPG database on port 5432